### PR TITLE
Use http instead of https as default API protocol

### DIFF
--- a/nodes/cirrusminernode.py
+++ b/nodes/cirrusminernode.py
@@ -10,7 +10,7 @@ from api.voting import Voting
 
 
 class CirrusMinerNode(BaseNode):
-    def __init__(self, ipaddr: str = 'https://localhost', blockchainnetwork: BaseNetwork = CirrusMain(), devmode=False):
+    def __init__(self, ipaddr: str = 'http://localhost', blockchainnetwork: BaseNetwork = CirrusMain(), devmode=False):
         if not isinstance(blockchainnetwork, (CirrusMain, CirrusTest, CirrusRegTest)):
             raise ValueError('Invalid network. Must be one of: [CirrusMain, CirrusTest, CirrusRegTest]')
         super(CirrusMinerNode, self).__init__(name='Cirrus', ipaddr=ipaddr, blockchainnetwork=blockchainnetwork)

--- a/nodes/cirrusnode.py
+++ b/nodes/cirrusnode.py
@@ -11,7 +11,7 @@ from api.voting import Voting
 
 
 class CirrusNode(BaseNode):
-    def __init__(self, ipaddr: str = 'https://localhost', blockchainnetwork: BaseNetwork = CirrusMain()):
+    def __init__(self, ipaddr: str = 'http://localhost', blockchainnetwork: BaseNetwork = CirrusMain()):
         if not isinstance(blockchainnetwork, (CirrusMain, CirrusTest, CirrusRegTest)):
             raise ValueError('Invalid network. Must be one of: [CirrusMain, CirrusTest, CirrusRegTest]')
         super(CirrusNode, self).__init__(name='Cirrus', ipaddr=ipaddr, blockchainnetwork=blockchainnetwork)

--- a/nodes/interfluxnodes.py
+++ b/nodes/interfluxnodes.py
@@ -17,7 +17,7 @@ from api.voting import Voting
 
 
 class InterfluxStraxNode(BaseNode):
-    def __init__(self, ipaddr: str = 'https://localhost', blockchainnetwork: BaseNetwork = StraxMain()):
+    def __init__(self, ipaddr: str = 'http://localhost', blockchainnetwork: BaseNetwork = StraxMain()):
         if not isinstance(blockchainnetwork, (StraxMain, StraxTest, StraxRegTest)):
             raise ValueError('Invalid network. Must be one of: [StraxMain, StraxTest, StraxRegTest]')
         super(InterfluxStraxNode, self).__init__(name='InterfluxStrax', ipaddr=ipaddr, blockchainnetwork=blockchainnetwork)
@@ -77,7 +77,7 @@ class InterfluxStraxNode(BaseNode):
 
 
 class InterfluxCirrusNode(BaseNode):
-    def __init__(self, ipaddr: str = 'https://localhost', blockchainnetwork: BaseNetwork = CirrusMain()):
+    def __init__(self, ipaddr: str = 'http://localhost', blockchainnetwork: BaseNetwork = CirrusMain()):
         if not isinstance(blockchainnetwork, (CirrusMain, CirrusTest, CirrusRegTest)):
             raise ValueError('Invalid network. Must be one of: [CirrusMain, CirrusTest, CirrusRegTest]')
         super(InterfluxCirrusNode, self).__init__(name='InterfluxCirrus', ipaddr=ipaddr, blockchainnetwork=blockchainnetwork)

--- a/nodes/straxnode.py
+++ b/nodes/straxnode.py
@@ -8,7 +8,7 @@ from api.staking import Staking
 
 
 class StraxNode(BaseNode):
-    def __init__(self, ipaddr: str = 'https://localhost', blockchainnetwork: BaseNetwork = StraxMain()):
+    def __init__(self, ipaddr: str = 'http://localhost', blockchainnetwork: BaseNetwork = StraxMain()):
         if not isinstance(blockchainnetwork, (StraxMain, StraxTest, StraxRegTest)):
             raise ValueError('Invalid network. Must be one of: [StraxMain, StraxTest, StraxRegTest]')
         super(StraxNode, self).__init__(name='Strax', ipaddr=ipaddr, blockchainnetwork=blockchainnetwork)


### PR DESCRIPTION
 Stratis uses HTTP for API by default ([see in source code](https://github.com/stratisproject/StratisFullNode/blob/master/src/Stratis.Bitcoin.Features.Api/ApiSettings.cs#L17)).

Seems like there is no reason to force HTTPS connection in default constructors.