### PR TITLE
Extend .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@ Makefile
 # pytest
 /.pytest_cache/
 /.coverage
+/.vscode
+/env
+
+# Cache files
+__pycache__/
+*.pyc
 
 # Integration test node
 /integration_tests/StratisFullNode/


### PR DESCRIPTION
`env/` is used for the local **venv** environment.
This .gitignore can be used as a reference: https://github.com/github/gitignore/blob/master/Python.gitignore